### PR TITLE
scrollFinish doesn't account for the offset option

### DIFF
--- a/jquery.stickem.js
+++ b/jquery.stickem.js
@@ -4,7 +4,7 @@
  * @version 1.4
  *
  *	$('.container').stickem({
- *	 	item: '.stickem',
+ *		item: '.stickem',
  *		container: '.stickem-container',
  *		stickClass: 'stickit',
  *		endStickClass: 'stickit-end',
@@ -51,7 +51,7 @@
 
 		bindEvents: function() {
 			var _self = this;
-			
+
 			_self.$win.on('scroll.stickem', $.proxy(_self.handleScroll, _self));
 			_self.$win.on('resize.stickem', $.proxy(_self.handleResize, _self));
 		},

--- a/jquery.stickem.js
+++ b/jquery.stickem.js
@@ -89,7 +89,7 @@
 
 				item.containerInnerHeight = item.$container.height();
 				item.containerStart = item.$container.offset().top - _self.config.offset + _self.config.start + item.containerInner.padding.top + item.containerInner.border.top;
-				item.scrollFinish = item.containerStart - _self.config.start + (item.containerInnerHeight - item.elemHeight);
+				item.scrollFinish = item.containerStart - _self.config.start - _self.config.offset + (item.containerInnerHeight - item.elemHeight);
 
 				//If the element is smaller than the container
 				if(item.containerInnerHeight > item.elemHeight) {


### PR DESCRIPTION
Hi,

I don't really know if it's on purpose, but if I set the offset option, scrollFinish doesn't account for the offset and imho the stickit-end class gets injected too late.

Thanks for the really nice plugin.
