### PR TITLE
Fixed page load bug

### DIFF
--- a/jquery.stickem.js
+++ b/jquery.stickem.js
@@ -124,8 +124,8 @@
 				for(var i = 0, len = _self.items.length; i < len; i++) {
 					var item = _self.items[i];
 
-					//If it's stuck, and we need to unstick it
-					if(item.isStuck && (pos < item.containerStart || pos > item.scrollFinish)) {
+					//If it's stuck, and we need to unstick it, or if the page loads below it
+					if((item.isStuck && (pos < item.containerStart || pos > item.scrollFinish)) || pos > item.scrollFinish ) {
 						item.$elem.removeClass(_self.config.stickClass);
 
 						//only at the bottom


### PR DESCRIPTION
If the user loads the page halfway down (e.g. after a refresh, or after visiting an anchor) and then scrolls up, the sticky won't appear immediately.

Please see http://f.cl.ly/items/053f2L0e1T0x362c0G1I/demo%20of%20bug.mp4 for a demo of the bug
