### PR TITLE
DRY

### DIFF
--- a/jquery.stickem.js
+++ b/jquery.stickem.js
@@ -125,7 +125,7 @@
 					var item = _self.items[i];
 
 					//If it's stuck, and we need to unstick it, or if the page loads below it
-					if((item.isStuck && (pos < item.containerStart || pos > item.scrollFinish)) || pos > item.scrollFinish) {
+					if((item.isStuck && pos < item.containerStart) || pos > item.scrollFinish) {
 						item.$elem.removeClass(_self.config.stickClass);
 
 						//only at the bottom


### PR DESCRIPTION
The condition `pos > item.scrollFinish` was unnecessarily repeated.
